### PR TITLE
簡易 session 管理追加

### DIFF
--- a/app/controllers/app/NewUserCommit.scala
+++ b/app/controllers/app/NewUserCommit.scala
@@ -44,10 +44,12 @@ class NewUserCommitController @Inject()(
       },
       user   => {
         for {
-          _ <- userDAO.add(user)
+          userId <- userDAO.add(user)
         } yield {
-          // TODO: セッション追加処理
           Redirect("/recruit/intership-for-summer-21")
+            .withSession(
+              request.session + ("user_id" -> userId.toString)
+            )
         }
       }
     )

--- a/app/controllers/facility/FacilityController.scala
+++ b/app/controllers/facility/FacilityController.scala
@@ -15,6 +15,7 @@ import persistence.geo.model.Location
 import persistence.geo.dao.LocationDAO
 import model.site.facility.SiteViewValueFacilityList
 import model.component.util.ViewValuePageLayout
+import mvc.action.AuthenticationAction
 
 
 // 施設
@@ -29,7 +30,7 @@ class FacilityController @javax.inject.Inject()(
   /**
     * 施設一覧ページ
     */
-  def list = Action.async { implicit request =>
+  def list = (Action andThen AuthenticationAction()).async { implicit request =>
     for {
       locSeq      <- daoLocation.filterByIds(Location.Region.IS_PREF_ALL)
       facilitySeq <- facilityDao.findAll

--- a/app/mvc/action/AuthenticationAction.scala
+++ b/app/mvc/action/AuthenticationAction.scala
@@ -1,0 +1,31 @@
+package mvc.action
+
+import persistence.udb.model.User
+import play.api.mvc._
+import play.api.mvc.Results._
+
+import scala.concurrent.{ExecutionContext, Future}
+
+case class UserRequest[A](
+  userId:  User.Id,
+  request: Request[A]
+) extends WrappedRequest[A](request)
+
+case class AuthenticationAction()(implicit
+  val executionContext: ExecutionContext
+) extends ActionRefiner[Request, UserRequest] {
+
+  protected def refine[A](request: Request[A]): Future[Either[Result, UserRequest[A]]] = {
+    val sUserIdOpt = request.session.get("user_id")
+    val next = sUserIdOpt match {
+      case None          => Left(Redirect("/app/new-user", 301))
+      case Some(sUserId) => {
+        val userId      = sUserId.toLong
+        val userRequest = UserRequest(userId, request)
+        Right(userRequest)
+      }
+    }
+
+    Future.successful(next)
+  }
+}


### PR DESCRIPTION
(ログイン / ログアウト機能はつけてないです) 

現状ユーザ登録後にセッションを管理する機能がなかったので追加してます。

FacilityController.scala で認証処理をどのように追加しているか示していますが、
AuthenticationAction を合成すると session に userId がない場合は、
登録ページにリダイレクトするようにしています。